### PR TITLE
Improve PIN Entry and Alias Persistence

### DIFF
--- a/app/src/main/java/com/example/vuvur/DataModels.kt
+++ b/app/src/main/java/com/example/vuvur/DataModels.kt
@@ -47,8 +47,16 @@ sealed interface GalleryUiState {
         val apiAlias: String? = null
     ) : GalleryUiState
 
-    data class Scanning(val progress: Int, val total: Int) : GalleryUiState
-    data class Error(val message: String) : GalleryUiState
+    data class Scanning(
+        val progress: Int,
+        val total: Int,
+        val activeApiAlias: String = ""
+    ) : GalleryUiState
+
+    data class Error(
+        val message: String,
+        val activeApiAlias: String = ""
+    ) : GalleryUiState
     data class Success(
         val files: List<MediaFile> = emptyList(),
         val totalPages: Int = 1,

--- a/app/src/main/java/com/example/vuvur/MainActivity.kt
+++ b/app/src/main/java/com/example/vuvur/MainActivity.kt
@@ -163,9 +163,9 @@ fun AppNavigation() {
                             val activeApiDisplay = when (val state = uiState) {
                                 is GalleryUiState.Success -> state.activeApiAlias
                                 is GalleryUiState.Loading -> state.apiAlias ?: ""
-                                else -> ""
+                                is GalleryUiState.Scanning -> state.activeApiAlias
+                                is GalleryUiState.Error -> state.activeApiAlias
                             }
-                            // ✅ Add the fontSize parameter here
                             Text(
                                 text = "$currentTitle - $activeApiDisplay",
                                 fontSize = 18.sp

--- a/app/src/main/java/com/example/vuvur/screens/LockScreen.kt
+++ b/app/src/main/java/com/example/vuvur/screens/LockScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
@@ -63,25 +64,24 @@ fun LockScreen(onUnlock: () -> Unit) {
                 }
             } else if (enteredCode.length < 6) {
                 enteredCode += key
+                if (enteredCode.length == 6) {
+                    if (enteredCode == correctCode) {
+                        onUnlock()
+                    } else {
+                        scope.launch {
+                            snackbarHostState.showSnackbar("Incorrect passcode")
+                        }
+                        enteredCode = ""
+                    }
+                }
             }
         })
         Spacer(modifier = Modifier.height(16.dp))
-        Row {
-            Button(onClick = { enteredCode = "" }) {
-                Text("Clear")
-            }
-            Spacer(modifier = Modifier.width(8.dp))
-            Button(onClick = {
-                if (enteredCode == correctCode) {
-                    onUnlock()
-                } else {
-                    scope.launch {
-                        snackbarHostState.showSnackbar("Incorrect passcode")
-                    }
-                }
-            }) {
-                Text("Enter")
-            }
+        Button(
+            onClick = { enteredCode = "" },
+            modifier = Modifier.height(56.dp).width(120.dp)
+        ) {
+            Text("Clear", fontSize = 18.sp)
         }
     }
     }
@@ -89,27 +89,43 @@ fun LockScreen(onUnlock: () -> Unit) {
 
 @Composable
 fun NumericKeypad(onKeyPress: (String) -> Unit) {
-    Column {
+    val buttonModifier = Modifier.size(85.dp)
+    val fontSize = 24.sp
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
         (1..9).chunked(3).forEach { row ->
             Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 row.forEach { number ->
-                    Button(onClick = { onKeyPress(number.toString()) }) {
-                        Text(number.toString())
+                    Button(
+                        onClick = { onKeyPress(number.toString()) },
+                        modifier = buttonModifier
+                    ) {
+                        Text(number.toString(), fontSize = fontSize)
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(8.dp))
         }
         Row(
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Button(onClick = { onKeyPress("0") }) {
-                Text("0")
+            // Spacer to align 0 in the middle
+            Spacer(modifier = buttonModifier)
+            Button(
+                onClick = { onKeyPress("0") },
+                modifier = buttonModifier
+            ) {
+                Text("0", fontSize = fontSize)
             }
-            Button(onClick = { onKeyPress("backspace") }) {
-                Text("<-")
+            Button(
+                onClick = { onKeyPress("backspace") },
+                modifier = buttonModifier
+            ) {
+                Text("<-", fontSize = 18.sp)
             }
         }
     }


### PR DESCRIPTION
This change streamlines the PIN entry process by removing the need for an explicit "Enter" button and providing immediate feedback. It also improves the visibility of the currently active API configuration by ensuring its alias remains in the top app bar even when the app is in an error or scanning state.

---
*PR created automatically by Jules for task [2401018220539038975](https://jules.google.com/task/2401018220539038975) started by @djnixy*